### PR TITLE
Add compatibility for underdotted for pre nvim v0.7.3

### DIFF
--- a/lua/darkplus/theme.lua
+++ b/lua/darkplus/theme.lua
@@ -199,7 +199,11 @@ theme.set_highlights = function()
   hl(0, "markdownListMarker", { fg = c.blue, bg = 'NONE' })
   hl(0, "markdownOrderedListMarker", { fg = c.purple, bg = 'NONE' })
   hl(0, "markdownRule", { fg = c.gray, bg = 'NONE' })
-  hl(0, "markdownUrl", { fg = c.cyan, bg = 'NONE', underdotted=true, })
+  if vim.fn.has("nvim-0.7.3") == 1 then
+    hl(0, "markdownUrl", { fg = c.cyan, bg = 'NONE', underdotted=true, })
+  else
+    hl(0, "markdownUrl", { fg = c.cyan, bg = 'NONE', underdot=true, })
+  end
   hl(0, "markdownLinkText", { fg = c.blue, bg = 'NONE' })
   hl(0, "markdownFootnote", { fg = c.orange, bg = 'NONE' })
   hl(0, "markdownFootnoteDefinition", { fg = c.orange, bg = 'NONE' })


### PR DESCRIPTION
`underdotted` option in `nvim_set_hl` is only available in neovim nightly at this time, which causes an error for stable neovim users, and theme won't load correctly.
This PR adds support for the latest release v0.7.2 by using `underdot`.