### PR TITLE
fix: switches underdotter and underdot arround

### DIFF
--- a/lua/darkplus/theme.lua
+++ b/lua/darkplus/theme.lua
@@ -202,7 +202,7 @@ theme.set_highlights = function()
   if vim.fn.has("nvim-0.7.3") == 1 then
     hl(0, "markdownUrl", { fg = c.cyan, bg = 'NONE', underdot=true, })
   else
-    hl(0, "markdownUrl", { fg = c.cyan, bg = 'NONE', underdot=true, })
+    hl(0, "markdownUrl", { fg = c.cyan, bg = 'NONE', underdotted=true, })
   end
   hl(0, "markdownLinkText", { fg = c.blue, bg = 'NONE' })
   hl(0, "markdownFootnote", { fg = c.orange, bg = 'NONE' })

--- a/lua/darkplus/theme.lua
+++ b/lua/darkplus/theme.lua
@@ -200,7 +200,7 @@ theme.set_highlights = function()
   hl(0, "markdownOrderedListMarker", { fg = c.purple, bg = 'NONE' })
   hl(0, "markdownRule", { fg = c.gray, bg = 'NONE' })
   if vim.fn.has("nvim-0.7.3") == 1 then
-    hl(0, "markdownUrl", { fg = c.cyan, bg = 'NONE', underdotted=true, })
+    hl(0, "markdownUrl", { fg = c.cyan, bg = 'NONE', underdot=true, })
   else
     hl(0, "markdownUrl", { fg = c.cyan, bg = 'NONE', underdot=true, })
   end


### PR DESCRIPTION
This made the 'darkplus' theme stop working for me.
It is a tiny fix.