### PR TITLE
fix : Gitsigns toggle_current_line_blame not showing gitblame not vis…

### DIFF
--- a/lua/darkplus/theme.lua
+++ b/lua/darkplus/theme.lua
@@ -229,6 +229,7 @@ theme.set_highlights = function()
   hl(0, "GitSignsAdd", { fg = c.sign_add, bg = 'NONE' })
   hl(0, "GitSignsChange", { fg = c.sign_change, bg = 'NONE' })
   hl(0, "GitSignsDelete", { fg = c.sign_delete, bg = 'NONE' })
+  hl(0, "GitSignsCurrentLineBlame", {fg = c.gray, bg = 'NONE'})
 
   -- LSP
   hl(0, "DiagnosticHint", { fg = c.hint, bg = 'NONE' })


### PR DESCRIPTION
As mentioned in (this issue )[https://github.com/LunarVim/darkplus.nvim/issues/12] the gitsing blame isn't showing, that's because the `GitSignsCurrentLineBlame` ins't set, so the default darkvalue doesn't contrast with the background, as mentioned in [this other issue](https://github.com/lewis6991/gitsigns.nvim/issues/169#issuecomment-875652994).

Trying to get as close as possible to vscode and using the existing color pallet i put it to `gray`, now it looks like the images below.


![Neovim darkplus](https://github.com/LunarVim/darkplus.nvim/assets/85769349/e369570d-0a59-45ff-a8cd-6d2f1c1df463)

![vscode darkplus](https://github.com/LunarVim/darkplus.nvim/assets/85769349/9148a3ee-2764-4b4f-82d1-2baaf676a99d)

