### PR TITLE
Fix changing colors

### DIFF
--- a/lua/darkplus/theme.lua
+++ b/lua/darkplus/theme.lua
@@ -60,7 +60,7 @@ theme.set_highlights = function()
   hl(0, "TabLineFill", { fg = c.alt_fg, bg = c.alt_bg })
   hl(0, "WinSeparator", { fg = c.light_gray, bg = 'NONE' })
 
-  hl(0, "Comment", { fg = c.light_gray, bg = 'NONE', italic = true, })
+  hl(0, "Comment", { fg = c.green_1, bg = 'NONE' })
   hl(0, "Variable", { fg = c.blue_2, bg = 'NONE' })
   hl(0, "String", { fg = c.orange, bg = 'NONE' })
   hl(0, "Character", { fg = c.orange, bg = 'NONE' })
@@ -123,7 +123,7 @@ theme.set_highlights = function()
 
 
   -- Treesitter
-  hl(0, "@comment", { fg = c.green_1, bg = 'NONE', italic = true, })
+  hl(0, "@comment", { link = 'Comment' })
   hl(0, "@none", { fg = 'NONE', bg = 'NONE' })
   hl(0, "@preproc", { link = 'PreProc' })
   hl(0, "@define", { link = 'Define' })


### PR DESCRIPTION
Before this PR, comments ~~and keywords~~ are changing colors when you load to file:

https://github.com/LunarVim/darkplus.nvim/assets/29818440/8b27cec1-548c-45d5-8026-979979756cda

This PR makes comments always green without italic (just like in vscode) ~~and treats builtin functions as functions so they are yellow~~.

Unfortunately variables that are used as functions (like `hl` in the video) are still changing colors. I assume neovim thinks it's a function because it has a `(` next to it so it gives the yellow highlight, then treesitter says it's just a variable and changes it back to light blue. I believe if lua_ls recognized it being a function it wouldn't change colors and stay yellow.

![darkplus-pr](https://github.com/LunarVim/darkplus.nvim/assets/29818440/9a60d802-8c76-4ce2-a181-e615ce7827a4)

Edit: removed "fix" for functions as it has been already implemented at https://github.com/LunarVim/darkplus.nvim/commit/d04d43da4b204a9911fd301754d0868b0dbfbde1#diff-f6396e3ad2299402e37c1ffe426fc126f7c6bfc3ef40b49eed8ed657447a1442L127.