### PR TITLE
Add `@keyword.import.javascript` hl group

### DIFF
--- a/lua/darkplus/theme.lua
+++ b/lua/darkplus/theme.lua
@@ -474,6 +474,9 @@ theme.set_highlights = function()
   hl(0, "@tag.tsx", { fg = c.cyan, bg = 'NONE' })
   hl(0, "@tag.jsx", { fg = c.cyan, bg = 'NONE' })
 
+  -- Javascript
+  hl(0, "@keyword.import.javascript", { fg = c.purple, bg = 'NONE' })
+
   -- CSS
   hl(0, "@string.special.css", { fg = c.dark_yellow, bg = 'NONE' })
   hl(0, "@type.definition.css", { fg = c.blue_2, bg = 'NONE' })


### PR DESCRIPTION
This commit adds a new highlighting group, `@keyword.import.javascript`, to ensure consistency in the appearance of the "import" keyword in `jsx` and `tsx` files.

![BEFORE](https://github.com/LunarVim/darkplus.nvim/assets/53271437/d5c2ba8c-7cc8-4654-8185-f128203e3ea3)  
![AFTER](https://github.com/LunarVim/darkplus.nvim/assets/53271437/3566d93b-2f15-462b-9676-521a8ff83b81)

